### PR TITLE
feat: Configure Jitpack publishing and update AGP

### DIFF
--- a/ScreenShotSender/build.gradle.kts
+++ b/ScreenShotSender/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("maven-publish")
 }
 
 android {
@@ -29,6 +30,20 @@ android {
     }
     kotlinOptions {
         jvmTarget = "11"
+    }
+}
+
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                groupId = "com.github.cdcountrydelight"
+                artifactId = "screenShotSender"
+                version = "1.0.0"
+                from(components["release"])
+            }
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.2"
+agp = "8.12.3"
 kotlin = "2.2.10"
 coreKtx = "1.17.0"
 junit = "4.13.2"

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk17
+before_install:
+  - ./scripts/prepareJitpackEnvironment.sh


### PR DESCRIPTION
This commit introduces Jitpack configuration for publishing the `ScreenShotSender` library and updates the Android Gradle Plugin (AGP) version.

Key changes:
- Added a `jitpack.yml` file to specify JDK 17 and a pre-install script (`./scripts/prepareJitpackEnvironment.sh`) for the Jitpack build environment.
- Updated the Android Gradle Plugin version from `8.12.2` to `8.12.3` in `gradle/libs.versions.toml`.
- Added the `maven-publish` plugin to `ScreenShotSender/build.gradle.kts`.
- Configured a `release` Maven publication within `ScreenShotSender/build.gradle.kts`:
    - `groupId`: `com.github.cdcountrydelight`
    - `artifactId`: `screenShotSender`
    - `version`: `1.0.0`
    - Sources from `components["release"]`.