### PR TITLE
feat: Integrate ScreenShotSenderSDK via JitPack

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,8 @@ android {
 dependencies {
 
     implementation(libs.androidx.core.ktx)
-    implementation(project("::ScreenShotSender"))
+//    implementation(project("::ScreenShotSender"))
+    implementation(libs.screenshotsendersdk)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ retrofit = "2.11.0"
 gson = "2.13.1"
 okhttp = "5.1.0"
 chucker = "4.2.0"
+screenshotsendersdk = "1.0.0"
 
 
 [libraries]
@@ -40,6 +41,7 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 chucker-debug = { module = "com.github.chuckerteam.chucker:library", version.ref = "chucker" }
 chucker-release = { module = "com.github.chuckerteam.chucker:library-no-op", version.ref = "chucker" }
+screenshotsendersdk = { module = "com.github.arpit-cd:ScreenShotSenderSDK", version.ref = "screenshotsendersdk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
This commit updates the project to use the ScreenShotSenderSDK as a remote dependency from JitPack instead of a local module.

Key changes:
- Added `screenshotsendersdk = "1.0.0"` version in `gradle/libs.versions.toml`.
- Defined `screenshotsendersdk = { module = "com.github.arpit-cd:ScreenShotSenderSDK", version.ref = "screenshotsendersdk" }` in the `[libraries]` section of `gradle/libs.versions.toml`.
- In `app/build.gradle.kts`:
    - Commented out the local project dependency: `//implementation(project("::ScreenShotSender"))`.
    - Added the remote dependency: `implementation(libs.screenshotsendersdk)`.
- Added JitPack repository `maven { url = uri("https://jitpack.io") }` to `settings.gradle.kts` under `dependencyResolutionManagement { repositories { ... } }`.