### PR TITLE
feat: Add production and QA environment support

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="CHOOSE_PER_TEST" />
+        <option name="testRunner" value="GRADLE" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/ScreenShotSender/build.gradle.kts
+++ b/ScreenShotSender/build.gradle.kts
@@ -40,7 +40,7 @@ afterEvaluate {
             create<MavenPublication>("release") {
                 groupId = "com.github.cdcountrydelight"
                 artifactId = "screenShotSender"
-                version = "1.0.1"
+                version = "1.0.2"
                 from(components["release"])
             }
         }

--- a/ScreenShotSender/src/main/java/com/cd/screenshotsender/data/network/HttpClientManager.kt
+++ b/ScreenShotSender/src/main/java/com/cd/screenshotsender/data/network/HttpClientManager.kt
@@ -18,6 +18,8 @@ internal object HttpClientManager {
     @Volatile
     private var apiService: SendScreenShotApiService? = null
 
+    var isProdEnv = true
+
     fun getApiService(context: Context): SendScreenShotApiService {
         return apiService ?: synchronized(this) {
             apiService ?: createRetrofit(context).create(SendScreenShotApiService::class.java)
@@ -30,7 +32,7 @@ internal object HttpClientManager {
     private fun createRetrofit(context: Context): Retrofit {
         return retrofit ?: synchronized(this) {
             retrofit ?: Retrofit.Builder()
-                .baseUrl("https://qa-stock.countrydelight.in/api/cd_training/")
+                .baseUrl(if (isProdEnv) "https://stock.countrydelight.in/api/cd_training/" else "https://qa-stock.countrydelight.in/api/cd_training/")
                 .client(createOkHttpClient(context))
                 .addConverterFactory(
                     GsonConverterFactory.create(
@@ -46,10 +48,12 @@ internal object HttpClientManager {
     }
 
     private fun createOkHttpClient(context: Context): OkHttpClient {
-        return OkHttpClient.Builder()
+        val baseClient = OkHttpClient.Builder()
             .addInterceptor(AppNetworkInterceptorImpl(context))
-            .addInterceptor(getChuckerInterceptor(context))
-            .connectTimeout(30, TimeUnit.SECONDS)
+        if (!isProdEnv) {
+            baseClient.addInterceptor(getChuckerInterceptor(context))
+        }
+        return baseClient.connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .build()

--- a/ScreenShotSender/src/main/java/com/cd/screenshotsender/presentation/ScreenShotSenderSDK.kt
+++ b/ScreenShotSender/src/main/java/com/cd/screenshotsender/presentation/ScreenShotSenderSDK.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.Build
 import android.provider.Settings
 import androidx.core.net.toUri
+import com.cd.screenshotsender.data.network.HttpClientManager
 import com.cd.screenshotsender.presentation.service.ScreenShotSenderService
 import com.cd.screenshotsender.presentation.utils.FunctionHelper.showToast
 
@@ -16,8 +17,9 @@ object ScreenShotSenderSDK {
     fun startSDK(
         activity: Activity,
         resultCode: Int,
+        isProdEnv: Boolean,
         resultData: Intent?,
-        packageName: String? = null
+        packageName: String? = null,
     ) {
         if (!Settings.canDrawOverlays(activity)) {
             requestOverlayPermission(activity)
@@ -28,6 +30,8 @@ object ScreenShotSenderSDK {
             intent.putExtra("packageName", packageName ?: activity.packageName)
             intent.putExtra("resultCode", resultCode)
             intent.putExtra("data", resultData)
+            intent.putExtra("isProdEnv", isProdEnv)
+            HttpClientManager.isProdEnv = isProdEnv
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 activity.startForegroundService(intent)
             } else {

--- a/app/src/main/java/com/cd/screenshotsendersdk/MainActivity.kt
+++ b/app/src/main/java/com/cd/screenshotsendersdk/MainActivity.kt
@@ -44,8 +44,9 @@ class MainActivity : ComponentActivity() {
                 ScreenShotSenderSDK.startSDK(
                     this,
                     result.resultCode,
+                    false,
                     result.data!!,
-                    "deliveryapp.countrydelight.in.deliveryapp"
+                    "deliveryapp.countrydelight.in.deliveryapp",
                 )
             } else {
                 Toast.makeText(this, "Screen capture permission denied", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
This commit introduces the ability to configure the SDK to point to either a production or a QA environment. A new `isProdEnv` boolean parameter has been added to the `startSDK` method to control the target base URL for network requests.

Additionally, the Chucker interceptor will now only be active in the QA environment to prevent it from running in production builds.

Key changes:
- **`ScreenShotSenderSDK.kt`**:
    - The `startSDK` method now accepts an `isProdEnv: Boolean` parameter.
    - This flag is passed to the `ScreenShotSenderService` via an intent extra and is used to configure the `HttpClientManager`.
- **`HttpClientManager.kt`**:
    - A new `isProdEnv` property has been added, which defaults to `true`.
    - The Retrofit `baseUrl` is now dynamically selected based on the `isProdEnv` flag ("stock.countrydelight.in" for prod, "qa-stock.countrydelight.in" for QA).
    - The `ChuckerInterceptor` is now conditionally added to the OkHttpClient only when `isProdEnv` is `false`.
- **`ScreenShotSender/build.gradle.kts`**:
    - The library version has been incremented from `1.0.1` to `1.0.2`.
- **Sample App (`MainActivity.kt`)**:
    - The call to `startSDK` has been updated to include the new `isProdEnv` parameter.